### PR TITLE
feat: allow accessing touch and mouse handlers and the dragContainer ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ render() {
 |onPanEnd|`func`| |Fired on pan end|
 |preventPan|`func`| |Defines a function to prevent pan|
 |style|`object`| |Override the inline-styles of the root element|
+|onMouseDown|`func`| |Fired on mouse down|
+|onMouseUp|`func`| |Fired on mouse up|
+|onMouseMove|`func`| |Fired on mouse move|
+|onTouchStart|`func`| |Fired on touch start|
+|onTouchMove|`func`| |Fired on touch move|
+|onTouchEnd|`func`| |Fired on touch end|
+|onDragContainerRef|`func`| |Called with the dragContainer ref which gets the matrix transform applied|
 
 ## Methods
 By using `ref`, methods from `PanZoom` can be accessed and called to trigger manipulation functions.

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -18,6 +18,13 @@ type Props = {
   onPanStart?: (any) => void,
   onPan?: (any) => void,
   onPanEnd?: (any) => void,
+  onMouseDown?: (any) => void,
+  onMouseUp?: (any) => void,
+  onMouseMove?: (any) => void,
+  onTouchStart?: (any) => void,
+  onTouchMove?: (any) => void,
+  onTouchEnd?: (any) => void,
+  onDragContainerRef?: (any) => void,
 }
 
 // Transform matrix use to rotate, zoom and pan
@@ -137,6 +144,9 @@ class PanZoom extends React.Component<Props> {
   }
 
   onMouseDown = (e) => {
+    if (this.props.onMouseDown) {
+      this.props.onMouseDown(e)
+    }
     const { preventPan } = this.props
     if (this.props.disabled) {
       return
@@ -181,6 +191,9 @@ class PanZoom extends React.Component<Props> {
   }
 
   onMouseMove = (e) => {
+    if (this.props.onMouseMove) {
+      this.props.onMouseMove(e)
+    }
     if (this.panning) {
       const { noStateUpdate } = this.props
 
@@ -203,6 +216,9 @@ class PanZoom extends React.Component<Props> {
   }
 
   onMouseUp = (e) => {
+    if (this.props.onMouseUp) {
+      this.props.onMouseUp(e)
+    }
     // if using noStateUpdate we still need to set the new values in the state
     this.dispatchStateUpdateIfNeeded()
 
@@ -265,6 +281,9 @@ class PanZoom extends React.Component<Props> {
   }
 
   onTouchStart = (e) => {
+    if (this.props.onTouchStart) {
+      this.props.onTouchStart(e)
+    }
     const { preventPan } = this.props
     if (e.touches.length === 1) {
       // Drag
@@ -297,6 +316,9 @@ class PanZoom extends React.Component<Props> {
   }
 
   onToucheMove = (e) => {
+    if (this.props.onTouchMove) {
+      this.props.onTouchMove(e)
+    }
     const { realPinch, noStateUpdate } = this.props
     if (e.touches.length === 1) {
       e.stopPropagation()
@@ -347,6 +369,9 @@ class PanZoom extends React.Component<Props> {
   }
 
   onTouchEnd = (e) => {
+    if (this.props.onTouchEnd) {
+      this.props.onTouchEnd(e)
+    }
     if (e.touches.length > 0) {
       const offset = this.getOffset(e.touches[0])
       this.mousePos = {
@@ -698,7 +723,12 @@ class PanZoom extends React.Component<Props> {
         style={{ cursor: disabled ? 'initial' : 'pointer', ...style }}
       >
         <div
-          ref={ref => this.dragContainer = ref}
+          ref={ref => {
+            this.dragContainer = ref
+            if (this.props.onDragContainerRef) {
+              this.props.onDragContainerRef(ref)
+            } 
+          }}
           style={{
             display: 'inline-block',
             transformOrigin: '0 0 0',


### PR DESCRIPTION
I need to access the mouse and touch events for some custom gestures/events like a long press.

In my specific use-case, I want to implement a long press event with the following custom hook:

```jsx
export const useLongPress = (callback = () => {}, ms = 300) => {
  const [startLogPress, setStartLongPress] = useState(false);
  const currentEventRef = useRef(null);

  useEffect(() => {
    let timerId;
    if (startLogPress) {
      timerId = setTimeout(() => {
        callback(currentEventRef.current);
        currentEventRef.current = null;
      }, ms);
    } else {
      clearTimeout(timerId);
      currentEventRef.current = null;
    }

    return () => {
      clearTimeout(timerId);
    };
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [startLogPress]);

  return {
    onMouseDown: ev => {
      ev.persist();
      currentEventRef.current = ev;
      setStartLongPress(true);
    },
    onMouseUp: () => setStartLongPress(false),
    onMouseMove: () => setStartLongPress(false),
    onTouchMove: () => setStartLongPress(false),
    onMouseLeave: () => setStartLongPress(false),
    onTouchStart: ev => {
      ev.persist();
      currentEventRef.current = ev;
      setStartLongPress(true);
    },
    onTouchEnd: () => setStartLongPress(false)
  };
};
```

Usage example:

```jsx
const MyComponent = ({ children }) => {
  const longPressAttributes = useLongPress(() => alert("TEST"));
  return (
    <PanZoom {...longPressAttributes}>
      {children}
    </PanZoom>
  );
}

```

In order to make this possible, I added some additional properties for the touch and mouse events.


Furthermore, I am calculating the real coordinates of the target. In order to to do so, I need access to the `dragContainer` element which has the CSS matrix transform. For doing this I added an optional `onDragContainerRef` callback.

Access to the `dragContainer` is currently also possible however via the `ref` but not documented.

@mnogueron Please let me know your thoughts on this.