### PR TITLE
feat: add disableDoubleClickZoom property

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ render() {
 |doubleZoomSpeed|`number`|1.75|Sets the zoom speed for double click|
 |disabled|`bool`|false|Disable pan and zoom|
 |disableKeyInteraction|`bool`|false|Disable keyboard interaction|
+|disableDoubleClickZoom|`bool`|false|Disable zoom when performing a double click|
 |realPinch|`bool`|false|Enable real pinch interaction for touch events|
 |keyMapping|`object`|false|Define specific key mapping for keyboard interaction (e.g. `{ '<keyCode>': { x: 0, y: 1, z: 0 } }`, with `<keyCode>` being the key code to map)|
 |minZoom|`number`| |Sets the minimum zoom value|

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -8,6 +8,7 @@ type Props = {
   autoCenter?: boolean,
   autoCenterZoomLevel?: number,
   disableKeyInteraction?: boolean,
+  disableDoubleClickZoom?: Boolean,
   realPinch?: boolean,
   keyMapping?: { [string]: { x: number, y: number, z: number }},
   minZoom?: number,
@@ -131,7 +132,10 @@ class PanZoom extends React.Component<Props> {
   }
 
   onDoubleClick = (e) => {
-    const { doubleZoomSpeed } = this.props
+    const { disableDoubleClickZoom, doubleZoomSpeed } = this.props
+    if (disableDoubleClickZoom) {
+      return
+    }
     const offset = this.getOffset(e)
     this.zoomTo(offset.x, offset.y, doubleZoomSpeed)
   }
@@ -722,6 +726,7 @@ PanZoom.defaultProps = {
   noStateUpdate: true,
   boundaryRatioVertical: 0.8,
   boundaryRatioHorizontal: 0.8,
+  disableDoubleClickZoom: false,
 
   preventPan: () => false,
 }

--- a/stories/PanZoom.stories.js
+++ b/stories/PanZoom.stories.js
@@ -183,3 +183,13 @@ storiesOf('react-easy-panzoom', module)
       realPinch={boolean('Enable real pinch', false)}
     />
   ))
+  .add('Disable Double Click Zoom Event', () => (
+    <DefaultPanZoom
+      maxZoom={Infinity}
+      disableDoubleClickZoom={boolean('Disabel Double Click Zoom', true)}
+    >
+      <Box>
+        Double Click should not zoom
+      </Box>
+    </DefaultPanZoom>
+  ))

--- a/stories/PanZoom.stories.js
+++ b/stories/PanZoom.stories.js
@@ -186,7 +186,7 @@ storiesOf('react-easy-panzoom', module)
   .add('Disable Double Click Zoom Event', () => (
     <DefaultPanZoom
       maxZoom={Infinity}
-      disableDoubleClickZoom={boolean('Disabel Double Click Zoom', true)}
+      disableDoubleClickZoom={boolean('Disable Double Click Zoom', true)}
     >
       <Box>
         Double Click should not zoom


### PR DESCRIPTION
closes #4

Adds a new property `disableDoubleClickZoom` to the `PanZoom` component that allows disabling the doubleClick zoom. I also added a new storybook example for testing this feature.