### PR TITLE
feat: onChange prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ render() {
 |onPanEnd|`func`| |Fired on pan end|
 |preventPan|`func`| |Defines a function to prevent pan|
 |style|`object`| |Override the inline-styles of the root element|
+|onChange|`func`| |Called after the pan/zoom has changed|
 
 You can also pass in every other props you would pass to a `div` element. Those will be passed through to the container component. This is helpful for adding custom event handlers.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ render() {
 |onPanEnd|`func`| |Fired on pan end|
 |preventPan|`func`| |Defines a function to prevent pan|
 |style|`object`| |Override the inline-styles of the root element|
-|onChange|`func`| |Called after the pan/zoom has changed|
+|onStateChange|`func`| |Called after the state of the component has changed|
 
 You can also pass in every other props you would pass to a `div` element. Those will be passed through to the container component. This is helpful for adding custom event handlers.
 

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -1,6 +1,14 @@
 // @flow
 import * as React from 'react'
 import warning from 'warning'
+
+type OnChangeData = {
+  x: number,
+  y: number,
+  scale: number,
+  rotate: number
+}
+
 type Props = {
   zoomSpeed?: number,
   doubleZoomSpeed?: number,
@@ -19,6 +27,7 @@ type Props = {
   onPanStart?: (any) => void,
   onPan?: (any) => void,
   onPanEnd?: (any) => void,
+  onChange?: (data: OnChangeData) => void,
 }
 
 // Transform matrix use to rotate, zoom and pan
@@ -116,10 +125,24 @@ class PanZoom extends React.Component<Props> {
     }
   }
 
-  componentDidUpdate(prevProps): void {
+  componentDidUpdate(prevProps, prevState): void {
     if (prevProps.autoCenter !== this.props.autoCenter
       && this.props.autoCenter) {
       this.autoCenter(this.props.autoCenterZoomLevel)
+    }
+    if (
+      (prevState.x !== this.state.x
+      || prevState.y !== this.state.y
+      || prevState.scale!== this.state.scale
+      || prevState.rotate !== this.state.scale.rotate)
+      && this.props.onChange
+    ) {
+      this.props.onChange({
+        x: this.state.x,
+        y: this.state.y,
+        scale: this.state.scale,
+        rotate: this.state.rotate
+      })
     }
   }
 

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -133,8 +133,8 @@ class PanZoom extends React.Component<Props> {
     if (
       (prevState.x !== this.state.x
       || prevState.y !== this.state.y
-      || prevState.scale!== this.state.scale
-      || prevState.rotate !== this.state.scale.rotate)
+      || prevState.scale !== this.state.scale
+      || prevState.rotate !== this.state.rotate)
       && this.props.onChange
     ) {
       this.props.onChange({

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import warning from 'warning'
 
-type OnChangeData = {
+type OnStateChangeData = {
   x: number,
   y: number,
   scale: number,
@@ -27,7 +27,7 @@ type Props = {
   onPanStart?: (any) => void,
   onPan?: (any) => void,
   onPanEnd?: (any) => void,
-  onChange?: (data: OnChangeData) => void,
+  onStateChange?: (data: OnStateChangeData) => void,
 }
 
 // Transform matrix use to rotate, zoom and pan
@@ -135,9 +135,9 @@ class PanZoom extends React.Component<Props> {
       || prevState.y !== this.state.y
       || prevState.scale !== this.state.scale
       || prevState.rotate !== this.state.rotate)
-      && this.props.onChange
+      && this.props.onStateChange
     ) {
-      this.props.onChange({
+      this.props.onStateChange({
         x: this.state.x,
         y: this.state.y,
         scale: this.state.scale,

--- a/stories/PanZoom.stories.js
+++ b/stories/PanZoom.stories.js
@@ -193,3 +193,18 @@ storiesOf('react-easy-panzoom', module)
       </Box>
     </DefaultPanZoom>
   ))
+  .add('onChange handler', () => {
+    return (
+      <>
+        <DefaultPanZoom
+          onChange={(data) =>{
+           console.log(data)
+          }}     
+        >
+          <Box>
+            Open the console then move me
+          </Box>
+        </DefaultPanZoom>
+      </>
+    )
+  })

--- a/stories/PanZoom.stories.js
+++ b/stories/PanZoom.stories.js
@@ -193,11 +193,11 @@ storiesOf('react-easy-panzoom', module)
       </Box>
     </DefaultPanZoom>
   ))
-  .add('onChange handler', () => {
+  .add('onStateChange handler', () => {
     return (
       <>
         <DefaultPanZoom
-          onChange={(data) =>{
+          onStateChange={(data) => {
            console.log(data)
           }}     
         >


### PR DESCRIPTION
This pull request adds an `onChange` property which is called after a pan/zoom interaction.

This feature is quite helpful in case you need to calculate something based on the x, y, rotate and zoom value.

In my specific usecase, I calculate the actual clicked coordinates on the element with https://github.com/ombr/referentiel

Any time the x, y, rotate or zoom value have changed I, therefore, need to update my Referentiel instance.