### PR TITLE
feat: allow setting key, touch and mouse event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ render() {
 |preventPan|`func`| |Defines a function to prevent pan|
 |style|`object`| |Override the inline-styles of the root element|
 
+You can also pass in every other props you would pass to a `div` element. Those will be passed through to the container component. This is helpful for adding custom event handlers.
+
 ## Methods
 By using `ref`, methods from `PanZoom` can be accessed and called to trigger manipulation functions.
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "peerDependencies": {
     "react": ">=16.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "warning": "4.0.3"
+  },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.4",

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -132,16 +132,23 @@ class PanZoom extends React.Component<Props> {
   }
 
   onDoubleClick = (e) => {
-    const { disableDoubleClickZoom, doubleZoomSpeed } = this.props
+    const { onDoubleClick, disableDoubleClickZoom, doubleZoomSpeed } = this.props
+    if (onDoubleClick !== undefined) {
+      onDoubleClick(e)
+    }
     if (disableDoubleClickZoom) {
       return
     }
+
     const offset = this.getOffset(e)
     this.zoomTo(offset.x, offset.y, doubleZoomSpeed)
   }
 
   onMouseDown = (e) => {
-    const { preventPan } = this.props
+    const { preventPan, onMouseDown } = this.props
+    if (onMouseDown !== undefined) {
+      onMouseDown(e)
+    }
     if (this.props.disabled) {
       return
     }
@@ -228,7 +235,10 @@ class PanZoom extends React.Component<Props> {
   }
 
   onKeyDown = (e) => {
-    const { keyMapping, disableKeyInteraction } = this.props
+    const { keyMapping, disableKeyInteraction, onKeyDown } = this.props
+    if (onKeyDown !== undefined) {
+      onKeyDown(e)
+    }
 
     if (disableKeyInteraction) {
       return
@@ -269,7 +279,10 @@ class PanZoom extends React.Component<Props> {
   }
 
   onTouchStart = (e) => {
-    const { preventPan } = this.props
+    const { preventPan, onTouchStart } = this.props
+    if (onTouchStart !== undefined) {
+      onTouchStart(e)
+    }
     if (e.touches.length === 1) {
       // Drag
       const touch = e.touches[0]
@@ -675,7 +688,33 @@ class PanZoom extends React.Component<Props> {
   }
 
   render() {
-    const { children, style, disabled, disableKeyInteraction } = this.props
+    const {
+      children,
+      autoCenter,
+      autoCenterZoomLevel,
+      zoomSpeed,
+      doubleZoomSpeed,
+      disabled,
+      disableKeyInteraction,
+      realPinch,
+      keyMapping,
+      minZoom,
+      maxZoom,
+      enableBoundingBox,
+      boundaryRatioVertical,
+      boundaryRatioHorizontal,
+      noStateUpdate,
+      onPanStart,
+      onPan,
+      onPanEnd,
+      preventPan,
+      style,
+      onDoubleClick,
+      onMouseDown,
+      onKeyDown,
+      onTouchStart,
+      ...props
+    } = this.props
     const { x, y, scale, rotate } = this.state
     const { a, b, c, d, x: transformX, y: transformY} = this.getTransformMatrix(x, y, scale, rotate)
     const transform = this.getTransformMatrixString(a, b, c, d, transformX, transformY)

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -701,6 +701,7 @@ class PanZoom extends React.Component<Props> {
       zoomSpeed,
       doubleZoomSpeed,
       disabled,
+      disableDoubleClickZoom,
       disableKeyInteraction,
       realPinch,
       keyMapping,

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -744,7 +744,7 @@ class PanZoom extends React.Component<Props> {
       )
       warning(
         onTouchStart === undefined || typeof onTouchStart === 'function',
-        "Warning: Expected `onTouchStart` listener to be a function, instead got a value of `%s` type.",
+        "Expected `onTouchStart` listener to be a function, instead got a value of `%s` type.",
         typeof onTouchStart
       )
     }

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -713,7 +713,7 @@ class PanZoom extends React.Component<Props> {
       onMouseDown,
       onKeyDown,
       onTouchStart,
-      ...props
+      ...restPassThroughProps
     } = this.props
     const { x, y, scale, rotate } = this.state
     const { a, b, c, d, x: transformX, y: transformY} = this.getTransformMatrix(x, y, scale, rotate)
@@ -739,7 +739,7 @@ class PanZoom extends React.Component<Props> {
         onKeyDown={this.onKeyDown}
         onTouchStart={this.onTouchStart}
         style={{ cursor: disabled ? 'initial' : 'pointer', ...style }}
-        {...props}
+        {...restPassThroughProps}
       >
         <div
           ref={ref => this.dragContainer = ref}

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import warning from 'warning';
+import warning from 'warning'
 type Props = {
   zoomSpeed?: number,
   doubleZoomSpeed?: number,

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-
+import warning from 'warning';
 type Props = {
   zoomSpeed?: number,
   doubleZoomSpeed?: number,
@@ -133,9 +133,11 @@ class PanZoom extends React.Component<Props> {
 
   onDoubleClick = (e) => {
     const { onDoubleClick, disableDoubleClickZoom, doubleZoomSpeed } = this.props
-    if (onDoubleClick !== undefined) {
+
+    if (typeof onDoubleClick === 'function') {
       onDoubleClick(e)
     }
+
     if (disableDoubleClickZoom) {
       return
     }
@@ -146,9 +148,11 @@ class PanZoom extends React.Component<Props> {
 
   onMouseDown = (e) => {
     const { preventPan, onMouseDown } = this.props
-    if (onMouseDown !== undefined) {
+
+    if (typeof onMouseDown === 'function') {
       onMouseDown(e)
     }
+
     if (this.props.disabled) {
       return
     }
@@ -236,8 +240,9 @@ class PanZoom extends React.Component<Props> {
 
   onKeyDown = (e) => {
     const { keyMapping, disableKeyInteraction, onKeyDown } = this.props
-    if (onKeyDown !== undefined) {
-      onKeyDown(e)
+
+    if (typeof onKeyDown === 'function') {
+        onKeyDown(e)
     }
 
     if (disableKeyInteraction) {
@@ -280,9 +285,10 @@ class PanZoom extends React.Component<Props> {
 
   onTouchStart = (e) => {
     const { preventPan, onTouchStart } = this.props
-    if (onTouchStart !== undefined) {
+    if (typeof onTouchStart === 'function') {
       onTouchStart(e)
     }
+
     if (e.touches.length === 1) {
       // Drag
       const touch = e.touches[0]
@@ -718,6 +724,29 @@ class PanZoom extends React.Component<Props> {
     const { x, y, scale, rotate } = this.state
     const { a, b, c, d, x: transformX, y: transformY} = this.getTransformMatrix(x, y, scale, rotate)
     const transform = this.getTransformMatrixString(a, b, c, d, transformX, transformY)
+
+    if (process.env.NODE_ENV !== 'production') {
+      warning(
+        onDoubleClick === undefined || typeof onDoubleClick === 'function',
+        "Expected `onDoubleClick` listener to be a function, instead got a value of `%s` type.",
+        typeof onDoubleClick
+      )
+      warning(
+        onMouseDown === undefined || typeof onMouseDown === 'function',
+        "Expected `onMouseDown` listener to be a function, instead got a value of `%s` type.",
+        typeof onMouseDown
+      )
+      warning(
+        onKeyDown === undefined || typeof onKeyDown === 'function',
+        "Expected `onKeyDown` listener to be a function, instead got a value of `%s` type.",
+        typeof onKeyDown
+      )
+      warning(
+        onTouchStart === undefined || typeof onTouchStart === 'function',
+        "Warning: Expected `onTouchStart` listener to be a function, instead got a value of `%s` type.",
+        typeof onTouchStart
+      )
+    }
 
     return (
       <div

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -739,6 +739,7 @@ class PanZoom extends React.Component<Props> {
         onKeyDown={this.onKeyDown}
         onTouchStart={this.onTouchStart}
         style={{ cursor: disabled ? 'initial' : 'pointer', ...style }}
+        {...props}
       >
         <div
           ref={ref => this.dragContainer = ref}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9753,17 +9753,17 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+warning@4.0.3, warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
+
 warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
-  dependencies:
-    loose-envify "^1.0.0"
-
-warning@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
The project I am working on requires adding event listeners to the PanZoom component.

Ideally, this project would use prop getters (https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters). However, this is something to consider for a major release/braking change.

This implementation uses a list of allowed event property names in order to apply them from either the component instance methods or the props passed to the component instance.