### PR TITLE
feat: add option to disable animation for autoCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Available methods are listed below:
 |---|---|---|
 |zoomIn| |Zoom in from the center of the `PanZoom` container|
 |zoomOut| |Zoom out from the center of the `PanZoom` container|
-|autoCenter| |Center and resize the view to fit the `PanZoom` container|
+|autoCenter|`(zoom: number, animate?: boolean = true)`|Center and resize the view to fit the `PanZoom` container|
 |reset| |Reset the view to it's original state (will not auto center if `autoCenter` is enabled)|
 |moveByRatio|`(x: number, y: number, moveSpeedRatio?: number)`|Move the view along `x` or/and `y` axis|
 |rotate|`(angle: number \| (prevAngle) => newAngle)`|Rotate the view by the specified angle|

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -150,7 +150,7 @@ class PanZoom extends React.Component<Props, State> {
       throw new Error('[PanZoom]: maxZoom props cannot be inferior to minZoom')
     }
     if (autoCenter) {
-      this.autoCenter(autoCenterZoomLevel)
+      this.autoCenter(autoCenterZoomLevel, false)
     }
   }
 
@@ -556,7 +556,7 @@ class PanZoom extends React.Component<Props, State> {
     return dragContainer
   }
 
-  autoCenter = (zoomLevel: number = 1) => {
+  autoCenter = (zoomLevel: number = 1, animate: boolean = true) => {
     const container = this.getContainer()
     const dragContainer = this.getDragContainer()
     const { minZoom, maxZoom } = this.props
@@ -577,7 +577,20 @@ class PanZoom extends React.Component<Props, State> {
 
     const x = (containerRect.width - (clientWidth * scale)) / 2
     const y = (containerRect.height - (clientHeight * scale)) / 2
-    this.setState({ x, y, scale, rotate: 0 })
+    
+    let afterStateUpdate = undefined
+    if (!animate) {
+      const transition = dragContainer.style.transition
+      dragContainer.style.transition = "none"
+      afterStateUpdate = () => {
+        setTimeout(() => { 
+          const dragContainer = this.getDragContainer()
+          dragContainer.style.transition = transition
+        }, 0)
+      }
+    }
+
+    this.setState({ x, y, scale, rotate: 0 }, afterStateUpdate)
   }
 
   moveByRatio = (x: number, y: number, moveSpeedRatio: number = 0.05) => {

--- a/stories/PanZoom.stories.js
+++ b/stories/PanZoom.stories.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { withKnobs, boolean, number } from '@storybook/addon-knobs';
@@ -15,8 +15,9 @@ const Box = ({ children }) => (
   </div>
 )
 
-const DefaultPanZoom = (props) => (
+const DefaultPanZoom = React.forwardRef((props, ref) => (
   <PanZoom
+    ref={ref}
     style={{ border: 'solid 1px green', height: 500, overflow: 'hidden' }}
     minZoom={0.5}
     maxZoom={3}
@@ -25,7 +26,7 @@ const DefaultPanZoom = (props) => (
     noStateUpdate={true}
     {...props}
   />
-)
+))
 
 const PanZoomPreventPan = () => {
 
@@ -127,6 +128,22 @@ const PanZoomControlUI = (props) => {
   )
 }
 
+const AutoCenterDemo = ({ animate }) => {
+  const ref = useRef(null)
+  const [checked, setChecked] = useState(false)
+
+  return  (
+    <DefaultPanZoom ref={ref}>
+      <div style={{ padding: 10, border: "2px solid red"}}>
+        Move me then{" "}
+        <button onClick={() => {
+          ref.current.autoCenter(1, animate)
+        }}>AutoCenter</button>
+      </div>
+    </DefaultPanZoom>
+  )
+}
+
 storiesOf('react-easy-panzoom', module)
   .addDecorator(withKnobs)
   .add('Basic', () => (
@@ -208,3 +225,4 @@ storiesOf('react-easy-panzoom', module)
       </>
     )
   })
+  .add("autoCenter animate option", () => <AutoCenterDemo animate={boolean("Animate auto center", true)} />)


### PR DESCRIPTION
This pull request adds a new boolean property to the `autoFocus` method, which allows disabling the transition. This is useful if you initially want to load content without a janky animation.

I also disabled the transition for the autoFocus upon mounting the component, I did this because I would categorize it as unwanted behavior. In case this behavior is intended I can revert the changes.