### PR TITLE
fix: disabled prop on touch devices

### DIFF
--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -340,9 +340,13 @@ class PanZoom extends React.Component<Props, State> {
   }
 
   onTouchStart = (e: SyntheticTouchEvent<HTMLDivElement>) => {
-    const { preventPan, onTouchStart } = this.props
+    const { preventPan, onTouchStart, disabled } = this.props
     if (typeof onTouchStart === 'function') {
       onTouchStart(e)
+    }
+    
+    if (disabled) {
+      return
     }
 
     if (e.touches.length === 1) {


### PR DESCRIPTION
Currently, it is possible to drag around the PanZoom container content on touch devices despite `disabled` being set on the `PanZoom` component.

This small fix addresses the issue.