### PR TITLE
[Fix] Pan position start over after autocenter

### DIFF
--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -556,6 +556,7 @@ class PanZoom extends React.Component<Props, State> {
       }
     }
 
+    this.prevPanPosition = { x, y }
     this.setState({ x, y, scale, rotate: 0 }, afterStateUpdate)
   }
 

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import warning from 'warning'
-import { TransformMatrix, applyTransformMatrix } from './utils'
+import { TransformMatrix, getTransformedElementCoordinates, preventDefault } from './utils'
 
 type OnStateChangeData = {
   x: number,
@@ -39,37 +39,6 @@ type State = {
   y: number,
   scale: number,
   rotate: number
-}
-
-type TransformCoordinates = {
-  top: number,
-  left: number,
-  width: number,
-  height: number,
-}
-
-const getTransformedElementCoordinates = (angle, scale, offsetX, offsetY) => (element: HTMLElement): TransformCoordinates => {
-  const { clientTop, clientLeft, clientWidth, clientHeight } = element
-  const centerX = clientWidth / 2
-  const centerY = clientHeight / 2
-
-  const _applyTransformMatrix = applyTransformMatrix(angle, centerX, centerY, scale, offsetX, offsetY)
-
-  const [x1, y1] = _applyTransformMatrix(clientLeft, clientTop)
-  const [x2, y2] = _applyTransformMatrix(clientLeft + clientWidth, clientTop)
-  const [x3, y3] = _applyTransformMatrix(clientLeft + clientWidth, clientTop + clientHeight)
-  const [x4, y4] = _applyTransformMatrix(clientLeft, clientTop + clientHeight)
-
-  return {
-    top: Math.min(y1, y2, y3, y4),
-    left: Math.min(x1, x2, x3, x4),
-    width: Math.max(x1, x2, x3, x4) - Math.min(x1, x2, x3, x4),
-    height: Math.max(y1, y2, y3, y4) - Math.min(y1, y2, y3, y4),
-  }
-}
-
-const preventDefault = (e) => {
-  e.preventDefault()
 }
 
 class PanZoom extends React.Component<Props, State> {

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import warning from 'warning'
-import { TransformMatrix, getTransformedElementCoordinates, preventDefault } from './utils'
+import { TransformMatrix, getTransformedElementCoordinates, getScaleMultiplier } from './maths'
 
 type OnStateChangeData = {
   x: number,
@@ -39,6 +39,10 @@ type State = {
   y: number,
   scale: number,
   rotate: number
+}
+
+const preventDefault = (e) => {
+  e.preventDefault()
 }
 
 class PanZoom extends React.Component<Props, State> {
@@ -219,8 +223,12 @@ class PanZoom extends React.Component<Props, State> {
   }
 
   onMouseUp = (e: MouseEvent) => {
+    const { noStateUpdate } = this.props
+
     // if using noStateUpdate we still need to set the new values in the state
-    this.dispatchStateUpdateIfNeeded()
+    if (noStateUpdate) {
+      this.setState(({ x: this.prevPanPosition.x, y: this.prevPanPosition.y }))
+    }
 
     this.triggerOnPanEnd(e)
     this.cleanMouseListeners()
@@ -229,12 +237,12 @@ class PanZoom extends React.Component<Props, State> {
   }
 
   onWheel = (e: WheelEvent) => {
-    const { disableScrollZoom, disabled } = this.props
+    const { disableScrollZoom, disabled, zoomSpeed } = this.props
     if (disableScrollZoom || disabled) {
       return
     }
 
-    const scale = this.getScaleMultiplier(e.deltaY)
+    const scale = getScaleMultiplier(e.deltaY, zoomSpeed)
     const offset = this.getOffset(e)
     this.zoomTo(offset.x, offset.y, scale)
     e.preventDefault()
@@ -342,7 +350,7 @@ class PanZoom extends React.Component<Props, State> {
   }
 
   onToucheMove = (e: TouchEvent) => {
-    const { realPinch, noStateUpdate } = this.props
+    const { realPinch, noStateUpdate, zoomSpeed } = this.props
     if (e.touches.length === 1) {
       e.stopPropagation()
       const touch = e.touches[0]
@@ -378,7 +386,7 @@ class PanZoom extends React.Component<Props, State> {
         } else if (currentPinZoomLength > this.pinchZoomLength) {
           delta = -1
         }
-        scaleMultiplier = this.getScaleMultiplier(delta)
+        scaleMultiplier = getScaleMultiplier(delta, zoomSpeed)
       }
 
       this.mousePos = {
@@ -406,18 +414,15 @@ class PanZoom extends React.Component<Props, State> {
         y: this.state.y,
       }
     } else {
-      this.dispatchStateUpdateIfNeeded()
+      const { noStateUpdate } = this.props
+      if (noStateUpdate) {
+        this.setState(({ x: this.prevPanPosition.x, y: this.prevPanPosition.y }))
+      }
+
       this.touchInProgress = false
 
       this.triggerOnPanEnd(e)
       this.cleanTouchListeners()
-    }
-  }
-
-  dispatchStateUpdateIfNeeded = () => {
-    const { noStateUpdate } = this.props
-    if (noStateUpdate) {
-      this.setState(({ x: this.prevPanPosition.x, y: this.prevPanPosition.y }))
     }
   }
 
@@ -473,33 +478,25 @@ class PanZoom extends React.Component<Props, State> {
 
   triggerOnPanStart = (e: MouseEvent | TouchEvent) => {
     const { onPanStart } = this.props
-    if (!this.panStartTriggered) {
-      onPanStart && onPanStart(e)
+    if (!this.panStartTriggered && onPanStart && typeof onPanStart === 'function') {
+      onPanStart(e)
     }
     this.panStartTriggered = true
   }
 
   triggerOnPan = (e: MouseEvent | TouchEvent) => {
     const { onPan } = this.props
-    onPan && onPan(e)
+    if (typeof onPan === 'function') {
+      onPan(e)
+    }
   }
 
   triggerOnPanEnd = (e: MouseEvent | TouchEvent) => {
     const { onPanEnd } = this.props
     this.panStartTriggered = false
-    onPanEnd && onPanEnd(e)
-  }
-
-  getScaleMultiplier = (delta: number, zoomSpeed?: number) => {
-    let speed = 0.065 * (zoomSpeed || this.props.zoomSpeed)
-    let scaleMultiplier = 1
-    if (delta > 0) { // zoom out
-      scaleMultiplier = (1 - speed)
-    } else if (delta < 0) { // zoom in
-      scaleMultiplier = (1 + speed)
+    if (typeof onPanEnd === 'function') {
+      onPanEnd(e)
     }
-
-    return scaleMultiplier
   }
 
   getPinchZoomLength = (finger1: Touch, finger2: Touch) => {
@@ -655,7 +652,7 @@ class PanZoom extends React.Component<Props, State> {
 
   centeredZoom = (delta: number, zoomSpeed?: number) => {
     const container = this.getContainer()
-    const scaleMultiplier = this.getScaleMultiplier(delta, zoomSpeed)
+    const scaleMultiplier = getScaleMultiplier(delta, zoomSpeed || this.props.zoomSpeed)
     const containerRect = container.getBoundingClientRect()
     this.zoomTo(containerRect.width / 2, containerRect.height / 2, scaleMultiplier)
   }

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -648,6 +648,7 @@ class PanZoom extends React.Component<Props, State> {
     const newY = y - ratio * (y - transformY)
 
     const { boundX, boundY } = this.getBoundCoordinates(newX, newY, scale, rotate, newX, newY)
+    this.prevPanPosition = { boundX, boundY }
     this.setState({ x: boundX, y: boundY, scale: newScale })
   }
 

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -567,7 +567,7 @@ class PanZoom extends React.Component<Props, State> {
     const dx = offset * moveSpeedRatio * x
     const dy = offset * moveSpeedRatio * y
 
-    this.moveBy(dx, dy)
+    this.moveBy(dx, dy, false)
   }
 
   moveBy = (dx: number, dy: number, noStateUpdate?: boolean = true) => {
@@ -648,7 +648,7 @@ class PanZoom extends React.Component<Props, State> {
     const newY = y - ratio * (y - transformY)
 
     const { boundX, boundY } = this.getBoundCoordinates(newX, newY, scale, rotate, newX, newY)
-    this.prevPanPosition = { boundX, boundY }
+    this.prevPanPosition = { x: boundX, y: boundY }
     this.setState({ x: boundX, y: boundY, scale: newScale })
   }
 

--- a/src/maths.js
+++ b/src/maths.js
@@ -49,6 +49,14 @@ export const getTransformedElementCoordinates = (angle, scale, offsetX, offsetY)
   }
 }
 
-export const preventDefault = (e) => {
-  e.preventDefault()
+export const getScaleMultiplier = (delta: number, zoomSpeed: number) => {
+  let speed = 0.065 * zoomSpeed
+  let scaleMultiplier = 1
+  if (delta > 0) { // zoom out
+    scaleMultiplier = (1 - speed)
+  } else if (delta < 0) { // zoom in
+    scaleMultiplier = (1 + speed)
+  }
+
+  return scaleMultiplier
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,10 @@
+type TransformCoordinates = {
+  top: number,
+  left: number,
+  width: number,
+  height: number,
+}
+
 // Transform matrix use to rotate, zoom and pan
 // Can be written as T(centerX, centerY) * R(theta) * T(-centerX, -centerY) * S(scale, scale) + T(offsetX, offsetY)
 // ( a , c, x )
@@ -20,4 +27,28 @@ export const applyTransformMatrix = (angle, centerX, centerY, scale, offsetX, of
     x * a + y * c + transformX,
     x * b + y * d + transformY,
   ]
+}
+
+export const getTransformedElementCoordinates = (angle, scale, offsetX, offsetY) => (element: HTMLElement): TransformCoordinates => {
+  const { clientTop, clientLeft, clientWidth, clientHeight } = element
+  const centerX = clientWidth / 2
+  const centerY = clientHeight / 2
+
+  const _applyTransformMatrix = applyTransformMatrix(angle, centerX, centerY, scale, offsetX, offsetY)
+
+  const [x1, y1] = _applyTransformMatrix(clientLeft, clientTop)
+  const [x2, y2] = _applyTransformMatrix(clientLeft + clientWidth, clientTop)
+  const [x3, y3] = _applyTransformMatrix(clientLeft + clientWidth, clientTop + clientHeight)
+  const [x4, y4] = _applyTransformMatrix(clientLeft, clientTop + clientHeight)
+
+  return {
+    top: Math.min(y1, y2, y3, y4),
+    left: Math.min(x1, x2, x3, x4),
+    width: Math.max(x1, x2, x3, x4) - Math.min(x1, x2, x3, x4),
+    height: Math.max(y1, y2, y3, y4) - Math.min(y1, y2, y3, y4),
+  }
+}
+
+export const preventDefault = (e) => {
+  e.preventDefault()
 }


### PR DESCRIPTION
### Description

The pan position seems to restart when moving, using `noStateUpdate` and after an autocentering. This is due to the fact that `prevPanPosition` is set to `{ x: 0, y: 0 }` and not set after centering.

This PR is fixing this issue by setting `prevPanPosition` after centering.