### PR TITLE
[Feature] Simplify PanZoom component implementation

### DIFF
--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import warning from 'warning'
-import { TransformMatrix, getTransformedElementCoordinates, getScaleMultiplier, boundCoordinates } from './maths'
+import { TransformMatrix, getTransformedBoundingBox, getScaleMultiplier, boundCoordinates } from './maths'
 import { captureTextSelection, releaseTextSelection } from './events'
 
 type OnStateChangeData = {
@@ -707,9 +707,12 @@ class PanZoom extends React.Component<Props, State> {
 
     const { height: containerHeight, width: containerWidth } = this.getContainer().getBoundingClientRect()
     const { clientTop, clientLeft, clientWidth, clientHeight } = this.getDragContainer()
-    const { top, left, width, height } = getTransformedElementCoordinates(rotate, newScale, offsetX, offsetY, clientTop, clientLeft, clientWidth, clientHeight)
 
-    return boundCoordinates(x, y, boundaryRatioVertical, boundaryRatioHorizontal, containerHeight, containerWidth, top, left, width, height, offsetX, offsetY)
+    return boundCoordinates(x, y,
+      { vertical: boundaryRatioVertical, horizontal: boundaryRatioHorizontal },
+      getTransformedBoundingBox(rotate, newScale, offsetX, offsetY, { top: clientTop, left: clientLeft, width: clientWidth, height: clientHeight }),
+      containerHeight, containerWidth,
+      offsetX, offsetY)
   }
 
   render() {

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,11 @@
+export const preventDefault = (e) => {
+  e.preventDefault()
+}
+
+export const captureTextSelection = () => {
+  window.addEventListener('selectstart', preventDefault)
+}
+
+export const releaseTextSelection = () => {
+  window.removeEventListener('selectstart', preventDefault)
+}

--- a/src/maths.js
+++ b/src/maths.js
@@ -29,8 +29,7 @@ export const applyTransformMatrix = (angle, centerX, centerY, scale, offsetX, of
   ]
 }
 
-export const getTransformedElementCoordinates = (angle, scale, offsetX, offsetY) => (element: HTMLElement): TransformCoordinates => {
-  const { clientTop, clientLeft, clientWidth, clientHeight } = element
+export const getTransformedElementCoordinates = (angle, scale, offsetX, offsetY, clientTop, clientLeft, clientWidth, clientHeight): TransformCoordinates => {
   const centerX = clientWidth / 2
   const centerY = clientHeight / 2
 
@@ -59,4 +58,39 @@ export const getScaleMultiplier = (delta: number, zoomSpeed: number) => {
   }
 
   return scaleMultiplier
+}
+
+export const boundCoordinates = (
+  x: number, y: number,
+  boundaryRatioVertical: number, boundaryRatioHorizontal: number,
+  containerHeight: number, containerWidth: number,
+  top: number, left: number, width: number, height: number,
+  offsetX?: number = 0, offsetY?: number = 0) => {
+
+  // check that computed are inside boundaries otherwise set to the bounding box limits
+  let boundX = left
+  let boundY = top
+
+  if (boundY < -boundaryRatioVertical * height) {
+    boundY = -boundaryRatioVertical * height
+  }
+  else if (boundY > containerHeight - (1 - boundaryRatioVertical) * height) {
+    boundY = containerHeight - (1 - boundaryRatioVertical) * height
+  }
+
+  if (boundX < -boundaryRatioHorizontal * width) {
+    boundX = -boundaryRatioHorizontal * width
+  }
+  else if (boundX > containerWidth - (1 - boundaryRatioHorizontal) * width) {
+    boundX = containerWidth - (1 - boundaryRatioHorizontal) * width
+  }
+
+  // return new bounds coordinates for the transform matrix
+  // not the computed x/y coordinates
+  return {
+    boundX: x - (left - boundX),
+    boundY: y - (top - boundY),
+    offsetX: offsetX - (left - boundX),
+    offsetY: offsetY - (top - boundY),
+  }
 }

--- a/src/maths.js
+++ b/src/maths.js
@@ -33,6 +33,8 @@ export type TransformationParameters = {
   offsetY: number,
 }
 
+export const ZOOM_SPEED_MULTIPLIER = 0.065
+
 // Transform matrix use to rotate, zoom and pan
 // Can be written as T(centerX, centerY) * R(theta) * T(-centerX, -centerY) * S(scale, scale) + T(offsetX, offsetY)
 // ( a , c, x )
@@ -81,8 +83,8 @@ export const getTransformedBoundingBox = (transformationParameters: Transformati
   }
 }
 
-export const getScaleMultiplier = (delta: number, zoomSpeed: number): number => {
-  let speed = 0.065 * zoomSpeed
+export const getScaleMultiplier = (delta: number, zoomSpeed: number = 1): number => {
+  let speed = ZOOM_SPEED_MULTIPLIER * zoomSpeed
   let scaleMultiplier = 1
   if (delta > 0) { // zoom out
     scaleMultiplier = (1 - speed)

--- a/src/maths.js
+++ b/src/maths.js
@@ -1,4 +1,4 @@
-type TransformationMatrix = {
+export type TransformationMatrix = {
   a: number,
   b: number,
   c: number,
@@ -7,19 +7,19 @@ type TransformationMatrix = {
   y: number,
 }
 
-type BoundingBox = {
+export type BoundingBox = {
   top: number,
   left: number,
   width: number,
   height: number,
 }
 
-type BoundaryRatio = {
+export type BoundaryRatio = {
   vertical: number,
   horizontal: number,
 }
 
-type Coordinates = {
+export type Coordinates = {
   x: number,
   y: number,
 }

--- a/src/maths.test.js
+++ b/src/maths.test.js
@@ -1,0 +1,122 @@
+import * as maths from './maths'
+
+describe('getScaleMultiplier', () => {
+  test('delta == 0 should return 1', () => {
+    expect(maths.getScaleMultiplier(0)).toBe(1)
+  })
+
+  test('delta > 0 should return multiplier < 1', () => {
+    expect(maths.getScaleMultiplier(1)).toBeLessThan(1)
+  })
+
+  test('delta < 0 should return multiplier > 1', () => {
+    expect(maths.getScaleMultiplier(-1)).toBeGreaterThan(1)
+  })
+
+  test('should default to zoomSpeed == 1 if not set', () => {
+    expect(maths.getScaleMultiplier(1)).toBe(1 - maths.ZOOM_SPEED_MULTIPLIER)
+    expect(maths.getScaleMultiplier(-1)).toBe(1 + maths.ZOOM_SPEED_MULTIPLIER)
+  })
+})
+
+describe('TransformMatrix', () => {
+  test('should create valid translation matrix', () => {
+    expect(maths.TransformMatrix({
+      angle: 0,
+      scale: 1,
+      offsetX: 1,
+      offsetY: 1,
+    }, { x: 1, y: 1 })).toEqual({ a: 1, b: 0, c: -0, d: 1, x: 1, y: 1 })
+  })
+
+  test('should create valid scale matrix', () => {
+    expect(maths.TransformMatrix({
+      angle: 0,
+      scale: 2,
+      offsetX: 0,
+      offsetY: 0,
+    }, { x: 1, y: 1 })).toEqual({ a: 2, b: 0, c: -0, d: 2, x: 0, y: 0 })
+  })
+
+  test('should create valid rotation matrix', () => {
+    const matrix = maths.TransformMatrix({
+      angle: 90,
+      scale: 1,
+      offsetX: 0,
+      offsetY: 0,
+    }, { x: 1, y: 1 })
+    expect(matrix.a).toBeCloseTo(0)
+    expect(matrix.b).toBe(1)
+    expect(matrix.c).toBe(-1)
+    expect(matrix.d).toBeCloseTo(0)
+    expect(matrix.x).toBe(2)
+    expect(matrix.y).toBe(0)
+
+    const matrix1 = maths.TransformMatrix({
+      angle: 45,
+      scale: 1,
+      offsetX: 0,
+      offsetY: 0,
+    }, { x: 1, y: 1 })
+    expect(matrix1.a).toBeCloseTo(0.7071, 4)
+    expect(matrix1.b).toBeCloseTo(0.7071, 4)
+    expect(matrix1.c).toBeCloseTo(-0.7071, 4)
+    expect(matrix1.d).toBeCloseTo(0.7071, 4)
+    expect(matrix1.x).toBeCloseTo(1)
+    expect(matrix1.y).toBeCloseTo(-0.4142, 4)
+
+    const matrix2 = maths.TransformMatrix({
+      angle: 180,
+      scale: 1,
+      offsetX: 0,
+      offsetY: 0,
+    }, { x: 1, y: 1 })
+    expect(matrix2.a).toBe(-1)
+    expect(matrix2.b).toBeCloseTo(0)
+    expect(matrix2.c).toBeCloseTo(0)
+    expect(matrix2.d).toBe(-1)
+    expect(matrix2.x).toBe(2)
+    expect(matrix2.y).toBe(2)
+  })
+})
+
+describe('getTransformedBoundingBox', () => {
+  test('should return valid transformed bounding box', () => {
+    const boundingBox = maths.getTransformedBoundingBox({
+      angle: 45,
+      scale: 2,
+      offsetX: 1,
+      offsetY: 1,
+    }, { top: 1, left: 1, width: 1, height: 1 })
+    expect(boundingBox.top).toBeCloseTo(3.4142, 4)
+    expect(boundingBox.left).toBeCloseTo(0.5858, 4)
+    expect(boundingBox.width).toBeCloseTo(2.8284, 4)
+    expect(boundingBox.height).toBeCloseTo(2.8284, 4)
+  })
+})
+
+describe('boundCoordinates', () => {
+  test('should return valid bound coordinates if not exceeding boundaries', () => {
+    const boundCoordinates = maths.boundCoordinates(1, 1,
+      { vertical: 0.8, horizontal: 0.8 },
+      { top: 1, left: 1, width: 1, height: 1 },
+      2, 2, 1, 1,
+      )
+    expect(boundCoordinates.boundX).toBe(1)
+    expect(boundCoordinates.boundY).toBe(1)
+    expect(boundCoordinates.offsetX).toBe(1)
+    expect(boundCoordinates.offsetY).toBe(1)
+  })
+
+  test('should return valid bound coordinates if exceeding boundaries on x and y axis', () => {
+    const boundCoordinates = maths.boundCoordinates(2, 2,
+      { vertical: 0.8, horizontal: 0.8 },
+      { top: 2, left: 2, width: 1, height: 1 },
+      2, 2, 2, 2,
+    )
+    expect(boundCoordinates.boundX).toBe(1.8)
+    expect(boundCoordinates.boundY).toBe(1.8)
+    expect(boundCoordinates.offsetX).toBe(1.8)
+    expect(boundCoordinates.offsetY).toBe(1.8)
+  })
+})


### PR DESCRIPTION
### Description

This pr is meant to simplify `PanZoom` implementation by extracting static functions to their own file and add tests for it. This has mainly been done by moving out all of the mathematic functions to `maths.js` and create `maths.test.js` for the tests.

A lot of refactoring has been done to the internal functions to use objects instead of X parameters. Those have been typed to ensure that what is given to the function is correct.