### PR TITLE
Proposal: Add setScale method to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Available methods are listed below:
 |---|---|---|
 |zoomIn|`(zoomSpeed?: number)`|Zoom in from the center of the `PanZoom` container|
 |zoomOut|`(zoomSpeed?: number)`|Zoom out from the center of the `PanZoom` container|
+|setScale|`(scale?: number)`|Explicitly set the zoom amount via the scale.|
 |autoCenter|`(zoom: number, animate?: boolean = true)`|Center and resize the view to fit the `PanZoom` container|
 |reset| |Reset the view to it's original state (will not auto center if `autoCenter` is enabled)|
 |moveByRatio|`(x: number, y: number, moveSpeedRatio?: number)`|Move the view along `x` or/and `y` axis|

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -662,6 +662,10 @@ class PanZoom extends React.Component<Props, State> {
     this.centeredZoom(1, zoomSpeed)
   }
 
+  setScale = (scale?: number = 1) => {
+    this.setState({scale})
+  }
+
   reset = () => {
     this.setState({ x: 0, y: 0, scale: 1, angle: 0 })
   }

--- a/stories/ControllerUI/ScaleControllerUI.js
+++ b/stories/ControllerUI/ScaleControllerUI.js
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import Button from './Button'
+
+const ScaleControllerUI = ({ onSetScale }) => {
+  return (
+    <div
+      style={{
+        border: '2px solid rgba(0,0,0,0.2)',
+        borderRadius: 4,
+        overflow: 'hidden',
+        backgroundColor: 'white',
+      }}
+    >
+      <Button 
+        onClick={() => onSetScale(1)}
+        style={{
+          borderBottom: '1px solid #ccc',
+        }}
+      >
+        1
+      </Button>
+      <Button
+        onClick={() => onSetScale(0.75)}
+        style={{
+          borderBottom: '1px solid #ccc',
+        }}
+      >
+        .75
+      </Button>
+      <Button onClick={() => onSetScale(0.5)}>
+        .5
+      </Button>
+    </div>
+  )
+}
+
+export default ScaleControllerUI

--- a/stories/PanZoom.stories.js
+++ b/stories/PanZoom.stories.js
@@ -3,6 +3,7 @@ import React, { useRef } from 'react'
 import { storiesOf } from '@storybook/react'
 import { withKnobs, boolean, number } from '@storybook/addon-knobs';
 import ZoomControllerUI from './ControllerUI/ZoomControllerUI'
+import ScaleControllerUI from './ControllerUI/ScaleControllerUI'
 import PadControllerUI from './ControllerUI/PadControllerUI'
 import ResetControllerUI from './ControllerUI/ResetControllerUI'
 import RotationControllerUI from './ControllerUI/RotationControllerUI'
@@ -68,6 +69,10 @@ const PanZoomControlUI = (props) => {
     panZoom.current && panZoom.current.zoomOut(zoomOutSpeed)
   }
 
+  function onSetScale(scale) {
+    panZoom.current && panZoom.current.setScale(scale)
+  }
+
   function moveByRatio(x, y) {
     panZoom.current && panZoom.current.moveByRatio(x, y)
   }
@@ -105,6 +110,11 @@ const PanZoomControlUI = (props) => {
         <ZoomControllerUI
           onZoomIn={onZoomIn}
           onZoomOut={onZoomOut}
+        />
+      </div>
+      <div style={{ position: 'absolute', left: 50, top: 8, zIndex: 1 }}>
+        <ScaleControllerUI 
+          onSetScale={onSetScale}
         />
       </div>
 


### PR DESCRIPTION
👋 After opening https://github.com/mnogueron/react-easy-panzoom/issues/40 I decided to look at the code myself and found that it wouldn't be too crazy to introduce a `setScale` method to the component's API. 

The proposed method would fit a use case I've run across where I want to explicitly set the zoom level with a UI controller. Like this:
![Screen Shot 2020-02-24 at 10 22 37 AM](https://user-images.githubusercontent.com/3782604/75170478-c9bcfd80-56ef-11ea-9917-fc4f21d4ee0b.png)

Apologies if this is already doable and I am just wasting your time 😞 