### PR TITLE
Fix scaleMultiplier to be multiplicatively symmetrical

### DIFF
--- a/src/maths.js
+++ b/src/maths.js
@@ -84,12 +84,11 @@ export const getTransformedBoundingBox = (transformationParameters: Transformati
 }
 
 export const getScaleMultiplier = (delta: number, zoomSpeed: number = 1): number => {
-  let speed = ZOOM_SPEED_MULTIPLIER * zoomSpeed
   let scaleMultiplier = 1
   if (delta > 0) { // zoom out
-    scaleMultiplier = (1 - speed)
+    scaleMultiplier = (1 - (zoomSpeed * ZOOM_SPEED_MULTIPLIER))
   } else if (delta < 0) { // zoom in
-    scaleMultiplier = (1 + speed)
+    scaleMultiplier = (zoomSpeed / (1 - ZOOM_SPEED_MULTIPLIER))
   }
 
   return scaleMultiplier


### PR DESCRIPTION
The issue here is that when you zoom out, you reduce the scale by a factor of 0.065, but when you zoom in, you increase the scale by the same _additive_ factor, which is not multiplicatively symmetrical -- in order to undo multiplication by `0.935`, you need to multiply by `1.0695`, not by `1.065`.

You can see this erroneous behavior by zooming out one tick, then in one tick, then out one tick, so on and so forth -- it slowly continues to zoom out because the zoom in is _slightly_ too little.